### PR TITLE
Resolve symlink & Load jars recursively

### DIFF
--- a/lib/hdfs_jruby.rb
+++ b/lib/hdfs_jruby.rb
@@ -17,14 +17,7 @@ module Hdfs
   
   if ENV["HADOOP_HOME"]
     HADOOP_HOME=ENV["HADOOP_HOME"]
-    Dir["#{HADOOP_HOME}/#{JAR_PATTERN_0_20}",
-        "#{HADOOP_HOME}/lib/*.jar",
-        "#{HADOOP_HOME}/client/*.jar",
-        "#{HADOOP_HOME}/share/hadoop/common/*.jar",
-        "#{HADOOP_HOME}/share/hadoop/common/lib/*.jar",
-        "#{HADOOP_HOME}/share/hadoop/hdfs/*.jar",
-        "#{HADOOP_HOME}/share/hadoop/hdfs/lib/*.jar"
-        ].each  do |jar|
+    Dir["#{HADOOP_HOME}/*.jar", "#{HADOOP_HOME}/**/*.jar"].each do |jar|
       if File.symlink?(jar)
         link = File.readlink(jar)
         abs_path = File.expand_path(link, File.dirname(jar))

--- a/lib/hdfs_jruby.rb
+++ b/lib/hdfs_jruby.rb
@@ -25,6 +25,11 @@ module Hdfs
         "#{HADOOP_HOME}/share/hadoop/hdfs/*.jar",
         "#{HADOOP_HOME}/share/hadoop/hdfs/lib/*.jar"
         ].each  do |jar|
+      if File.symlink?(jar)
+        link = File.readlink(jar)
+        abs_path = File.expand_path(link, File.dirname(jar))
+        next unless File.exist?(abs_path)
+      end
       require jar
     end
     $CLASSPATH << "#{HADOOP_HOME}/conf"


### PR DESCRIPTION
@shinjiikeda Could you review this ? And then please release a new version.

CHANGES

- Read link and skip require if the file does not exist
  - Sometimes the symbolic link may have broken links, in which case Gem can not be used unless it is skipped.
- Load recursive under HADOOP_HOME
  - We use hdp2.5 which is deployed by ambari. In this case, the `#{HADOOP_HOME}/share` directories do not exist. So, in order to load required libraries, I change loading jars. 